### PR TITLE
Fix parameter name from is_haeder to is_header for clarity

### DIFF
--- a/src/wrp/zcl_wrap_bapi_po_create.clas.abap
+++ b/src/wrp/zcl_wrap_bapi_po_create.clas.abap
@@ -25,7 +25,7 @@ CLASS zcl_wrap_bapi_po_create IMPLEMENTATION.
 
     CALL METHOD zcl_ba_util=>set_bapi_x
       EXPORTING
-        is_bapi  = is_haeder
+        is_bapi  = is_header
 *       it_blanks    =
 *       it_constants =
       IMPORTING
@@ -48,7 +48,7 @@ CLASS zcl_wrap_bapi_po_create IMPLEMENTATION.
 
     zcl_wrap_bapi_po_create_async=>bapi_po_create(
       EXPORTING
-        i_poheader     = is_haeder
+        i_poheader     = is_header
         i_poheaderx    = ls_headerx
         i_no_authority = 'X'
       IMPORTING
@@ -71,7 +71,7 @@ CLASS zcl_wrap_bapi_po_create IMPLEMENTATION.
 
     CALL METHOD zcl_ba_util=>set_bapi_x
       EXPORTING
-        is_bapi  = is_haeder
+        is_bapi  = is_header
 *       it_blanks    =
 *       it_constants =
       IMPORTING
@@ -94,7 +94,7 @@ CLASS zcl_wrap_bapi_po_create IMPLEMENTATION.
 
     CALL FUNCTION 'BAPI_PO_CREATE1'
       EXPORTING
-        poheader     = is_haeder
+        poheader     = is_header
         poheaderx    = ls_headerx
         no_authority = 'X'
 *       poaddrvendor =

--- a/src/wrp/zif_wrap_bapi_po_create.intf.abap
+++ b/src/wrp/zif_wrap_bapi_po_create.intf.abap
@@ -10,7 +10,7 @@ INTERFACE zif_wrap_bapi_po_create
 
   METHODS create
     IMPORTING
-      is_haeder    TYPE tp_header
+      is_header    TYPE tp_header
       it_items     TYPE tp_items
     EXPORTING
       es_expheader TYPE tp_expheader
@@ -19,7 +19,7 @@ INTERFACE zif_wrap_bapi_po_create
 
   METHODS create_bo
     IMPORTING
-      is_haeder    TYPE tp_header
+      is_header    TYPE tp_header
       it_items     TYPE tp_items
     EXPORTING
       es_expheader TYPE tp_expheader

--- a/src/zbp_i_purchaseorder.clas.locals_imp.abap
+++ b/src/zbp_i_purchaseorder.clas.locals_imp.abap
@@ -74,7 +74,7 @@ CLASS lhc_zi_purchaseorder IMPLEMENTATION.
           " Chamar o método create da interface para criar o pedido de compra
           CALL METHOD lo_bapi_po_create->create
             EXPORTING
-              is_haeder    = ls_header
+              is_header    = ls_header
               it_items     = lt_items
             IMPORTING
               es_expheader = DATA(ls_expheader)
@@ -253,7 +253,7 @@ CLASS lsc_zi_purchaseorder IMPLEMENTATION.
         " Chamar o método create da interface para criar o pedido de compra
         CALL METHOD lo_bapi_po_create->create_bo
           EXPORTING
-            is_haeder    = ls_header
+            is_header    = ls_header
             it_items     = lt_items
           IMPORTING
             es_expheader = DATA(ls_expheader)


### PR DESCRIPTION
## Summary
- rename interface and class parameters `is_haeder` -> `is_header`
- update call sites referencing the changed parameter

## Testing
- `grep -R "is_haeder" -n`

------
https://chatgpt.com/codex/tasks/task_e_684186bef29c832ea66de0035d6a6059